### PR TITLE
Remove references to "Orange Team"

### DIFF
--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -4,7 +4,7 @@
     <link href="../static/css/base.css" th:href="@{/css/base.css}" rel="stylesheet"/>
     <link href="../static/css/standard-page.css" th:href="@{/css/standard-page.css}" rel="stylesheet"/>
 
-    <title>Orange Team Capture the Flag</title>
+    <title>Election CTF</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>

--- a/src/main/resources/templates/dev.html
+++ b/src/main/resources/templates/dev.html
@@ -4,7 +4,7 @@
     <link href="../static/css/base.css" th:href="@{/css/base.css}" rel="stylesheet"/>
     <link href="../static/css/standard-page.css" th:href="@{/css/standard-page.css}" rel="stylesheet"/>
 
-    <title>Orange Team Capture the Flag</title>
+    <title>Election CTF</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -4,7 +4,7 @@
     <link href="../static/css/base.css" th:href="@{/css/base.css}" rel="stylesheet"/>
     <link href="../static/css/index.css" th:href="@{/css/index.css}" rel="stylesheet"/>
 
-    <title>Orange Team Capture the Flag</title>
+    <title>Election CTF</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -4,7 +4,7 @@
     <link href="../../static/css/base.css" th:href="@{/css/base.css}" rel="stylesheet"/>
     <link href="../../static/css/index.css" th:href="@{/css/index.css}" rel="stylesheet"/>
 
-    <title>Orange Team Capture the Flag</title>
+    <title>Election CTF</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -4,7 +4,7 @@
     <link href="../../static/css/base.css" th:href="@{/css/base.css}" rel="stylesheet"/>
     <link href="../../static/css/index.css" th:href="@{/css/index.css}" rel="stylesheet"/>
 
-    <title>Orange Team Capture the Flag</title>
+    <title>Election CTF</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>

--- a/src/main/resources/templates/error/userNotFound.html
+++ b/src/main/resources/templates/error/userNotFound.html
@@ -4,7 +4,7 @@
     <link href="../../static/css/base.css" th:href="@{/css/base.css}" rel="stylesheet"/>
     <link href="../../static/css/index.css" th:href="@{/css/index.css}" rel="stylesheet"/>
 
-    <title>Orange Team Capture the Flag</title>
+    <title>Election CTF</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>

--- a/src/main/resources/templates/forgot.html
+++ b/src/main/resources/templates/forgot.html
@@ -4,7 +4,7 @@
     <link href="../static/css/base.css" th:href="@{/css/base.css}" rel="stylesheet"/>
     <link href="../static/css/index.css" th:href="@{/css/index.css}" rel="stylesheet"/>
 
-    <title>Orange Team Capture the Flag</title>
+    <title>Election CTF</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -4,7 +4,7 @@
     <link href="../static/css/base.css" th:href="@{/css/base.css}" rel="stylesheet" />
     <link href="../static/css/index.css" th:href="@{/css/index.css}" rel="stylesheet" />
 
-    <title>Orange Team Capture the Flag</title>
+    <title>Election CTF</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 </head>
 <body>

--- a/src/main/resources/templates/search.html
+++ b/src/main/resources/templates/search.html
@@ -5,7 +5,7 @@
     <link href="../static/css/standard-page.css" th:href="@{/css/standard-page.css}" rel="stylesheet"/>
     <link href="../static/css/search.css" th:href="@{/css/search.css}" rel="stylesheet"/>
 
-    <title>Orange Team Capture the Flag</title>
+    <title>Election CTF</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>

--- a/src/main/resources/templates/user.html
+++ b/src/main/resources/templates/user.html
@@ -4,7 +4,7 @@
     <link href="../static/css/base.css" th:href="@{/css/base.css}" rel="stylesheet"/>
     <link href="../static/css/standard-page.css" th:href="@{/css/standard-page.css}" rel="stylesheet"/>
 
-    <title>Orange Team Capture the Flag</title>
+    <title>Election CTF</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 </head>
 <body>


### PR DESCRIPTION
This change replaces "Orange Team Capture the Flag" with "Election
CTF" because "Orange Team" makes no sense outside the context of
605.731 Survey of Cloud Computing Security.